### PR TITLE
Add support for nvme-cli 2.11

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,57 +4,119 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/tidwall/gjson"
 	"log"
 	"net/http"
 	"os/exec"
 	"os/user"
-
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/tidwall/gjson"
+	"strings"
 )
 
-var labels = []string{"device"}
+var (
+	labels         = []string{"device"}
+	maxTempSensors = 8 // as per NVMe spec
+)
 
+// NVMe spec says there are 0 to 8 temperature sensors
 type nvmeCollector struct {
-	nvmeCriticalWarning *prometheus.Desc
-	nvmeTemperature *prometheus.Desc
-	nvmeAvailSpare *prometheus.Desc
-	nvmeSpareThresh *prometheus.Desc
-	nvmePercentUsed *prometheus.Desc
+	nvmeCriticalWarning                    *prometheus.Desc
+	nvmeAvailableSpare                     *prometheus.Desc
+	nvmeTempThreshold                      *prometheus.Desc
+	nvmeReliabilityDegraded                *prometheus.Desc
+	nvmeRO                                 *prometheus.Desc
+	nvmeVMBUFailed                         *prometheus.Desc
+	nvmePMRRO                              *prometheus.Desc
+	nvmeTemperature                        *prometheus.Desc
+	nvmeAvailSpare                         *prometheus.Desc
+	nvmeSpareThresh                        *prometheus.Desc
+	nvmePercentUsed                        *prometheus.Desc
 	nvmeEnduranceGrpCriticalWarningSummary *prometheus.Desc
-	nvmeDataUnitsRead *prometheus.Desc
-	nvmeDataUnitsWritten *prometheus.Desc
-	nvmeHostReadCommands *prometheus.Desc
-	nvmeHostWriteCommands *prometheus.Desc
-	nvmeControllerBusyTime *prometheus.Desc
-	nvmePowerCycles *prometheus.Desc
-	nvmePowerOnHours *prometheus.Desc
-	nvmeUnsafeShutdowns *prometheus.Desc
-	nvmeMediaErrors *prometheus.Desc
-	nvmeNumErrLogEntries *prometheus.Desc
-	nvmeWarningTempTime *prometheus.Desc
-	nvmeCriticalCompTime *prometheus.Desc
-	nvmeThmTemp1TransCount *prometheus.Desc
-	nvmeThmTemp2TransCount *prometheus.Desc
-	nvmeThmTemp1TotalTime *prometheus.Desc
-	nvmeThmTemp2TotalTime *prometheus.Desc
+	nvmeDataUnitsRead                      *prometheus.Desc
+	nvmeDataUnitsWritten                   *prometheus.Desc
+	nvmeHostReadCommands                   *prometheus.Desc
+	nvmeHostWriteCommands                  *prometheus.Desc
+	nvmeControllerBusyTime                 *prometheus.Desc
+	nvmePowerCycles                        *prometheus.Desc
+	nvmePowerOnHours                       *prometheus.Desc
+	nvmeUnsafeShutdowns                    *prometheus.Desc
+	nvmeMediaErrors                        *prometheus.Desc
+	nvmeNumErrLogEntries                   *prometheus.Desc
+	nvmeWarningTempTime                    *prometheus.Desc
+	nvmeCriticalCompTime                   *prometheus.Desc
+	nvmeTemperatureSensors                 []*prometheus.Desc
+	nvmeThmTemp1TransCount                 *prometheus.Desc
+	nvmeThmTemp2TransCount                 *prometheus.Desc
+	nvmeThmTemp1TotalTime                  *prometheus.Desc
+	nvmeThmTemp2TotalTime                  *prometheus.Desc
+	temperatureScale                       *string
 }
 
 // nvme smart-log field descriptions can be found on page 180 of:
 // https://nvmexpress.org/wp-content/uploads/NVM-Express-Base-Specification-2_0-2021.06.02-Ratified-5.pdf
 
-func newNvmeCollector() prometheus.Collector {
+func newNvmeCollector(temperatureScale *string) prometheus.Collector {
+	var sensorDescriptions []*prometheus.Desc
+	for i := 1; i <= maxTempSensors; i++ {
+		description := prometheus.NewDesc(
+			fmt.Sprintf("nvme_temperature_sensor%d", i),
+			fmt.Sprintf("Temperature reported by thermal sensor #%d in degrees %s", i, *temperatureScale),
+			labels,
+			nil,
+		)
+		sensorDescriptions = append(sensorDescriptions, description)
+	}
+
+	fmt.Sprintf("temperature scale: %s", temperatureScale)
 	return &nvmeCollector{
+		temperatureScale: temperatureScale,
 		nvmeCriticalWarning: prometheus.NewDesc(
 			"nvme_critical_warning",
 			"Critical warnings for the state of the controller",
 			labels,
 			nil,
 		),
+		nvmeAvailableSpare: prometheus.NewDesc(
+			"nvme_available_spare_critical",
+			"Has the 'available_spare' value dropped below 'spare_thresh'",
+			labels,
+			nil,
+		),
+		nvmeTempThreshold: prometheus.NewDesc(
+			"nvme_temp_threshold_exceeded",
+			"Temperature has exceeded the safe threshold",
+			labels,
+			nil,
+		),
+		nvmeReliabilityDegraded: prometheus.NewDesc(
+			"nvme_reliability_degraded",
+			"Device has degraded reliability due to excessive media/internal errors",
+			labels,
+			nil,
+		),
+		nvmeRO: prometheus.NewDesc(
+			"nvme_readonly",
+			"NVMe device is currently read-only",
+			labels,
+			nil,
+		),
+		nvmeVMBUFailed: prometheus.NewDesc(
+			"nvme_vmbu_failed",
+			"The 'Volatile Memory Backup Device' has failed, if present",
+			labels,
+			nil,
+		),
+		nvmePMRRO: prometheus.NewDesc(
+			"nvme_pmr_ro",
+			"The Persistent Memory Region is currently read-only",
+			labels,
+			nil,
+		),
 		nvmeTemperature: prometheus.NewDesc(
 			"nvme_temperature",
-			"Temperature in degrees fahrenheit",
+			fmt.Sprintf("Temperature in degrees %s", *temperatureScale),
 			labels,
 			nil,
 		),
@@ -154,6 +216,7 @@ func newNvmeCollector() prometheus.Collector {
 			labels,
 			nil,
 		),
+		nvmeTemperatureSensors: sensorDescriptions,
 		nvmeThmTemp1TransCount: prometheus.NewDesc(
 			"nvme_thm_temp1_trans_count",
 			"Number of times controller transitioned to lower power",
@@ -183,6 +246,12 @@ func newNvmeCollector() prometheus.Collector {
 
 func (c *nvmeCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.nvmeCriticalWarning
+	ch <- c.nvmeAvailableSpare
+	ch <- c.nvmeTempThreshold
+	ch <- c.nvmeReliabilityDegraded
+	ch <- c.nvmeRO
+	ch <- c.nvmeVMBUFailed
+	ch <- c.nvmePMRRO
 	ch <- c.nvmeTemperature
 	ch <- c.nvmeAvailSpare
 	ch <- c.nvmeSpareThresh
@@ -200,13 +269,80 @@ func (c *nvmeCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.nvmeNumErrLogEntries
 	ch <- c.nvmeWarningTempTime
 	ch <- c.nvmeCriticalCompTime
+	for i := 1; i <= maxTempSensors; i++ {
+		ch <- c.nvmeTemperatureSensors[i-1]
+	}
 	ch <- c.nvmeThmTemp1TransCount
 	ch <- c.nvmeThmTemp2TransCount
 	ch <- c.nvmeThmTemp1TotalTime
 	ch <- c.nvmeThmTemp2TotalTime
 }
 
-func (c *nvmeCollector) Collect(ch chan<- prometheus.Metric) {
+func (c *nvmeCollector) makeMetric(description *prometheus.Desc, valType prometheus.ValueType, result string, substring string, label string) prometheus.Metric {
+	value := gjson.Get(result, substring).Float()
+	if strings.Contains(substring, "temperature") {
+		// Leave it alone, if it's in Kelvin
+		if *c.temperatureScale == "celcius" {
+			value = value - 273
+		}
+		if *c.temperatureScale == "fahrenheit" {
+			value = (value-273.15)*9/5 + 32
+		}
+	}
+	return prometheus.MustNewConstMetric(description, valType, value, label)
+}
+
+func getDeviceList() []string {
+	/*
+		Modern versions of nvme-cli use 64bit ints for sizes, but have a new JSON format
+		Old version:
+		#  nvme list -o json | jq '.Devices[0]'
+		{
+		  "NameSpace": 1,
+		  "DevicePath": "/dev/nvme0n1",
+		  "Firmware": "XXXXXXXX",
+		  "ModelNumber": "XXXXXXX",
+		  "SerialNumber": "XXXXXXX",
+		  "UsedBytes": -2147483648,
+		  "MaximumLBA": 1875385008,
+		  "PhysicalSize": -2147483648,
+		  "SectorSize": 512
+		}
+		New version:
+		{
+		  "HostNQN": "nqn.2014-08.org.nvmexpress:uuid:XXXXXXX",
+		  "HostID": "XXXXXXX",
+		  "Subsystems": [
+		    {
+		      "Subsystem": "nvme-subsys0",
+		      "SubsystemNQN": "nqn.2016-08.com.micron:nvme:nvm-subsystem-sn-XXXXX",
+		      "Controllers": [
+		        {
+		          "Controller": "nvme0",
+		          "Cntlid": "0",
+		          "SerialNumber": "XXXXXX",
+		          "ModelNumber": "XXXXX",
+		          "Firmware": "XXXXX",
+		          "Transport": "pcie",
+		          "Address": "0000:02:00.0",
+		          "Slot": "9",
+		          "Namespaces": [
+		            {
+		              "NameSpace": "nvme0n1",
+		              "Generic": "ng0n1",
+		              "NSID": 1,
+		              "UsedBytes": 2097152,
+		              "MaximumLBA": 25004872368,
+		              "PhysicalSize": 12802494652416,
+		              "SectorSize": 512
+		            }
+		          ],
+		          "Paths": []
+		        }
+		      ],
+		      "Namespaces": []
+		    },...
+	*/
 	nvmeDeviceCmd, err := exec.Command("nvme", "list", "-o", "json").Output()
 	if err != nil {
 		log.Fatalf("Error running nvme command: %s\n", err)
@@ -214,67 +350,164 @@ func (c *nvmeCollector) Collect(ch chan<- prometheus.Metric) {
 	if !gjson.Valid(string(nvmeDeviceCmd)) {
 		log.Fatal("nvmeDeviceCmd json is not valid")
 	}
-	nvmeDeviceList := gjson.Get(string(nvmeDeviceCmd), "Devices.#.DevicePath")
-	for _, nvmeDevice := range nvmeDeviceList.Array() {
-		nvmeSmartLog, err := exec.Command("nvme", "smart-log", nvmeDevice.String(), "-o", "json").Output()
-		if err != nil {
-			log.Fatalf("Error running nvme smart-log command for device %s: %s\n", nvmeDevice.String(), err)
+	var deviceList []string
+	nvmeJsonDeviceList := gjson.Get(string(nvmeDeviceCmd), "Devices.#.DevicePath").Array()
+	if len(nvmeJsonDeviceList) > 0 {
+		for _, devicePath := range nvmeJsonDeviceList {
+			deviceList = append(deviceList, devicePath.String())
 		}
-		if !gjson.Valid(string(nvmeSmartLog)) {
-			log.Fatalf("nvmeSmartLog json is not valid for device: %s: %s\n", nvmeDevice.String(), err)
+		return deviceList
+	}
+	nvmeNamespaceList := gjson.Get(string(nvmeDeviceCmd), "Devices.#.Subsystems.#.Controllers.#.Namespaces.#.NameSpace")
+	if len(nvmeNamespaceList.Array()) > 0 {
+		for _, controller := range nvmeNamespaceList.Array() {
+			for _, namespaces := range controller.Array() {
+				for _, namespaceList := range namespaces.Array() {
+					for _, namespace := range namespaceList.Array() {
+						deviceList = append(deviceList, "/dev/"+namespace.String())
+					}
+				}
+			}
 		}
-		nvmeSmartLogMetrics := gjson.GetMany(string(nvmeSmartLog),
-                                                     "critical_warning",
-                                                     "temperature",
-                                                     "avail_spare",
-                                                     "spare_thresh",
-                                                     "percent_used",
-                                                     "endurance_grp_critical_warning_summary",
-                                                     "data_units_read",
-                                                     "data_units_written",
-                                                     "host_read_commands",
-                                                     "host_write_commands",
-                                                     "controller_busy_time",
-                                                     "power_cycles",
-                                                     "power_on_hours",
-                                                     "unsafe_shutdowns",
-                                                     "media_errors",
-                                                     "num_err_log_entries",
-                                                     "warning_temp_time",
-                                                     "critical_comp_time",
-                                                     "thm_temp1_trans_count",
-                                                     "thm_temp2_trans_count",
-                                                     "thm_temp1_total_time",
-                                                     "thm_temp2_total_time",)
+		return deviceList
+	} else {
+		log.Fatal("No NVMe Devices found \n")
+		return nil
+	}
+}
 
-		ch <- prometheus.MustNewConstMetric(c.nvmeCriticalWarning, prometheus.GaugeValue, nvmeSmartLogMetrics[0].Float(), nvmeDevice.String())
-		// convert kelvin to fahrenheit
-		ch <- prometheus.MustNewConstMetric(c.nvmeTemperature, prometheus.GaugeValue, (nvmeSmartLogMetrics[1].Float() - 273.15) * 9/5 + 32, nvmeDevice.String())
-		ch <- prometheus.MustNewConstMetric(c.nvmeAvailSpare, prometheus.GaugeValue, nvmeSmartLogMetrics[2].Float(), nvmeDevice.String())
-		ch <- prometheus.MustNewConstMetric(c.nvmeSpareThresh, prometheus.GaugeValue, nvmeSmartLogMetrics[3].Float(), nvmeDevice.String())
-		ch <- prometheus.MustNewConstMetric(c.nvmePercentUsed, prometheus.GaugeValue, nvmeSmartLogMetrics[4].Float(), nvmeDevice.String())
-		ch <- prometheus.MustNewConstMetric(c.nvmeEnduranceGrpCriticalWarningSummary, prometheus.GaugeValue, nvmeSmartLogMetrics[5].Float(), nvmeDevice.String())
-		ch <- prometheus.MustNewConstMetric(c.nvmeDataUnitsRead, prometheus.CounterValue, nvmeSmartLogMetrics[6].Float(), nvmeDevice.String())
-		ch <- prometheus.MustNewConstMetric(c.nvmeDataUnitsWritten, prometheus.CounterValue, nvmeSmartLogMetrics[7].Float(), nvmeDevice.String())
-		ch <- prometheus.MustNewConstMetric(c.nvmeHostReadCommands, prometheus.CounterValue, nvmeSmartLogMetrics[8].Float(), nvmeDevice.String())
-		ch <- prometheus.MustNewConstMetric(c.nvmeHostWriteCommands, prometheus.CounterValue, nvmeSmartLogMetrics[9].Float(), nvmeDevice.String())
-		ch <- prometheus.MustNewConstMetric(c.nvmeControllerBusyTime, prometheus.CounterValue, nvmeSmartLogMetrics[10].Float(), nvmeDevice.String())
-		ch <- prometheus.MustNewConstMetric(c.nvmePowerCycles, prometheus.CounterValue, nvmeSmartLogMetrics[11].Float(), nvmeDevice.String())
-		ch <- prometheus.MustNewConstMetric(c.nvmePowerOnHours, prometheus.CounterValue, nvmeSmartLogMetrics[12].Float(), nvmeDevice.String())
-		ch <- prometheus.MustNewConstMetric(c.nvmeUnsafeShutdowns, prometheus.CounterValue, nvmeSmartLogMetrics[13].Float(), nvmeDevice.String())
-		ch <- prometheus.MustNewConstMetric(c.nvmeMediaErrors, prometheus.CounterValue, nvmeSmartLogMetrics[14].Float(), nvmeDevice.String())
-		ch <- prometheus.MustNewConstMetric(c.nvmeNumErrLogEntries, prometheus.CounterValue, nvmeSmartLogMetrics[15].Float(), nvmeDevice.String())
-		ch <- prometheus.MustNewConstMetric(c.nvmeWarningTempTime, prometheus.CounterValue, nvmeSmartLogMetrics[16].Float(), nvmeDevice.String())
-		ch <- prometheus.MustNewConstMetric(c.nvmeCriticalCompTime, prometheus.CounterValue, nvmeSmartLogMetrics[17].Float(), nvmeDevice.String())
-		ch <- prometheus.MustNewConstMetric(c.nvmeThmTemp1TransCount, prometheus.CounterValue, nvmeSmartLogMetrics[18].Float(), nvmeDevice.String())
-		ch <- prometheus.MustNewConstMetric(c.nvmeThmTemp2TransCount, prometheus.CounterValue, nvmeSmartLogMetrics[19].Float(), nvmeDevice.String())
-		ch <- prometheus.MustNewConstMetric(c.nvmeThmTemp1TotalTime, prometheus.CounterValue, nvmeSmartLogMetrics[20].Float(), nvmeDevice.String())
-		ch <- prometheus.MustNewConstMetric(c.nvmeThmTemp2TotalTime, prometheus.CounterValue, nvmeSmartLogMetrics[21].Float(), nvmeDevice.String())
+func (c *nvmeCollector) Collect(ch chan<- prometheus.Metric) {
+	/*
+		Old style JSON:
+		# nvme smart-log -o json /dev/nvme0
+		{
+		  "critical_warning": 0,
+		  "temperature": 310,
+		  "avail_spare": 100,
+		  "spare_thresh": 10,
+		  "percent_used": 0,
+		  "endurance_grp_critical_warning_summary": 0,
+		  "data_units_read": 1765656.0,
+		  "data_units_written": 4445011.0,
+		  "host_read_commands": 195912399.0,
+		  "host_write_commands": 433050333.0,
+		  "controller_busy_time": 63.0,
+		  "power_cycles": 27.0,
+		  "power_on_hours": 6282.0,
+		  "unsafe_shutdowns": 21.0,
+		  "media_errors": 0.0,
+		  "num_err_log_entries": 0.0,
+		  "warning_temp_time": 0,
+		  "critical_comp_time": 0,
+		  "temperature_sensor_1": 318,
+		  "temperature_sensor_2": 312,
+		  "temperature_sensor_3": 310,
+		  "thm_temp1_trans_count": 0,
+		  "thm_temp2_trans_count": 0,
+		  "thm_temp1_total_time": 0,
+		  "thm_temp2_total_time": 0
+		}
+
+		New style JSON:
+		#  nvme smart-log -o json /dev/nvme0
+		{
+		  "critical_warning": {
+		    "value": 0,
+		    "available_spare": 0,
+		    "temp_threshold": 0,
+		    "reliability_degraded": 0,
+		    "ro": 0,
+		    "vmbu_failed": 0,
+		    "pmr_ro": 0
+		  },
+		  "temperature": 296,
+		  "avail_spare": 100,
+		  "spare_thresh": 10,
+		  "percent_used": 0,
+		  "endurance_grp_critical_warning_summary": 0,
+		  "data_units_read": 4540,
+		  "data_units_written": 16778,
+		  "host_read_commands": 151174,
+		  "host_write_commands": 99578,
+		  "controller_busy_time": 1,
+		  "power_cycles": 31,
+		  "power_on_hours": 907,
+		  "unsafe_shutdowns": 24,
+		  "media_errors": 0,
+		  "num_err_log_entries": 0,
+		  "warning_temp_time": 0,
+		  "critical_comp_time": 0,
+		  "temperature_sensor_1": 302,
+		  "temperature_sensor_2": 298,
+		  "temperature_sensor_3": 296,
+		  "thm_temp1_trans_count": 0,
+		  "thm_temp2_trans_count": 0,
+		  "thm_temp1_total_time": 0,
+		  "thm_temp2_total_time": 0
+		}
+
+	*/
+	nvmeDeviceList := getDeviceList()
+	for _, nvmeDevice := range nvmeDeviceList {
+		nvmeSmartLog, err := exec.Command("nvme", "smart-log", nvmeDevice, "-o", "json").Output()
+		nvmeSmartLogText := string(nvmeSmartLog)
+		if err != nil {
+			log.Fatalf("Error running nvme smart-log command for device %s: %s\n", nvmeDevice, err)
+		}
+		if !gjson.Valid(nvmeSmartLogText) {
+			log.Fatalf("nvmeSmartLog json is not valid for device: %s: %s\n", nvmeDevice, err)
+		}
+
+		nvmeCriticalWarning := gjson.Get(nvmeSmartLogText, "critical_warning")
+		if nvmeCriticalWarning.Type == gjson.JSON {
+			// It's the new format, where 'critical' is a full JSON section; temperature_sensor_1 etc. push the last four down a row
+			ch <- c.makeMetric(c.nvmeCriticalWarning, prometheus.GaugeValue, nvmeCriticalWarning.String(), "value", nvmeDevice)
+			ch <- c.makeMetric(c.nvmeAvailableSpare, prometheus.GaugeValue, nvmeCriticalWarning.String(), "available_spare", nvmeDevice)
+			ch <- c.makeMetric(c.nvmeTempThreshold, prometheus.GaugeValue, nvmeCriticalWarning.String(), "temp_threshold", nvmeDevice)
+			ch <- c.makeMetric(c.nvmeReliabilityDegraded, prometheus.GaugeValue, nvmeCriticalWarning.String(), "reliability_degraded", nvmeDevice)
+			ch <- c.makeMetric(c.nvmeRO, prometheus.GaugeValue, nvmeCriticalWarning.String(), "ro", nvmeDevice)
+			ch <- c.makeMetric(c.nvmeVMBUFailed, prometheus.GaugeValue, nvmeCriticalWarning.String(), "vmbu_failed", nvmeDevice)
+			ch <- c.makeMetric(c.nvmePMRRO, prometheus.GaugeValue, nvmeCriticalWarning.String(), "pmr_ro", nvmeDevice)
+
+			for i := 1; i <= maxTempSensors; i++ {
+				tempValue := gjson.Get(nvmeSmartLogText, fmt.Sprintf("temperature_sensor_%d", i))
+				if !tempValue.Exists() {
+					break
+				}
+				// ch <- prometheus.MustNewConstMetric(c.nvmeTemperatureSensors[i-1], prometheus.GaugeValue, tempValue.Float(), nvmeDevice)
+				ch <- c.makeMetric(c.nvmeTemperatureSensors[i-1], prometheus.GaugeValue, nvmeSmartLogText, fmt.Sprintf("temperature_sensor_%d", i), nvmeDevice)
+			}
+		} else {
+			ch <- c.makeMetric(c.nvmeCriticalWarning, prometheus.GaugeValue, nvmeSmartLogText, "critical_warning", nvmeDevice)
+		}
+
+		ch <- c.makeMetric(c.nvmeTemperature, prometheus.GaugeValue, nvmeSmartLogText, "temperature", nvmeDevice)
+		ch <- c.makeMetric(c.nvmeAvailSpare, prometheus.GaugeValue, nvmeSmartLogText, "avail_spare", nvmeDevice)
+		ch <- c.makeMetric(c.nvmeSpareThresh, prometheus.GaugeValue, nvmeSmartLogText, "spare_thresh", nvmeDevice)
+		ch <- c.makeMetric(c.nvmePercentUsed, prometheus.GaugeValue, nvmeSmartLogText, "percent_used", nvmeDevice)
+		ch <- c.makeMetric(c.nvmeEnduranceGrpCriticalWarningSummary, prometheus.GaugeValue, nvmeSmartLogText, "endurance_grp_critical_warning_summary", nvmeDevice)
+		ch <- c.makeMetric(c.nvmeDataUnitsRead, prometheus.CounterValue, nvmeSmartLogText, "data_units_read", nvmeDevice)
+		ch <- c.makeMetric(c.nvmeDataUnitsWritten, prometheus.CounterValue, nvmeSmartLogText, "data_units_written", nvmeDevice)
+		ch <- c.makeMetric(c.nvmeHostReadCommands, prometheus.CounterValue, nvmeSmartLogText, "host_read_commands", nvmeDevice)
+		ch <- c.makeMetric(c.nvmeHostWriteCommands, prometheus.CounterValue, nvmeSmartLogText, "host_write_commands", nvmeDevice)
+		ch <- c.makeMetric(c.nvmeControllerBusyTime, prometheus.CounterValue, nvmeSmartLogText, "controller_busy_time", nvmeDevice)
+		ch <- c.makeMetric(c.nvmePowerCycles, prometheus.CounterValue, nvmeSmartLogText, "power_cycles", nvmeDevice)
+		ch <- c.makeMetric(c.nvmePowerOnHours, prometheus.CounterValue, nvmeSmartLogText, "power_on_hours", nvmeDevice)
+		ch <- c.makeMetric(c.nvmeUnsafeShutdowns, prometheus.CounterValue, nvmeSmartLogText, "unsafe_shutdowns", nvmeDevice)
+		ch <- c.makeMetric(c.nvmeMediaErrors, prometheus.CounterValue, nvmeSmartLogText, "media_errors", nvmeDevice)
+		ch <- c.makeMetric(c.nvmeNumErrLogEntries, prometheus.CounterValue, nvmeSmartLogText, "num_err_log_entries", nvmeDevice)
+		ch <- c.makeMetric(c.nvmeWarningTempTime, prometheus.CounterValue, nvmeSmartLogText, "warning_temp_time", nvmeDevice)
+		ch <- c.makeMetric(c.nvmeCriticalCompTime, prometheus.CounterValue, nvmeSmartLogText, "critical_comp_time", nvmeDevice)
+		ch <- c.makeMetric(c.nvmeThmTemp1TransCount, prometheus.CounterValue, nvmeSmartLogText, "thm_temp1_trans_count", nvmeDevice)
+		ch <- c.makeMetric(c.nvmeThmTemp2TransCount, prometheus.CounterValue, nvmeSmartLogText, "thm_temp2_trans_count", nvmeDevice)
+		ch <- c.makeMetric(c.nvmeThmTemp1TotalTime, prometheus.CounterValue, nvmeSmartLogText, "thm_temp3_total_time", nvmeDevice)
+		ch <- c.makeMetric(c.nvmeThmTemp2TotalTime, prometheus.CounterValue, nvmeSmartLogText, "thm_temp1_total_time", nvmeDevice)
 	}
 }
 
 func main() {
 	port := flag.String("port", "9998", "port to listen on")
+	temperatureScale := flag.String("temperature_scale", "fahrenheit", "One of : [celcius | fahrenheit | kelvin]. NVMe standard recommens Kelvin.")
 	flag.Parse()
 	// check user
 	currentUser, err := user.Current()
@@ -289,7 +522,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Cannot find nvme command in path: %s\n", err)
 	}
-	prometheus.MustRegister(newNvmeCollector())
+	prometheus.MustRegister(newNvmeCollector(temperatureScale))
 	http.Handle("/metrics", promhttp.Handler())
 	log.Fatal(http.ListenAndServe(":"+*port, nil))
 }

--- a/main.go
+++ b/main.go
@@ -358,14 +358,12 @@ func getDeviceList() []string {
 		}
 		return deviceList
 	}
-	nvmeNamespaceList := gjson.Get(string(nvmeDeviceCmd), "Devices.#.Subsystems.#.Controllers.#.Namespaces.#.NameSpace")
-	if len(nvmeNamespaceList.Array()) > 0 {
-		for _, controller := range nvmeNamespaceList.Array() {
-			for _, namespaces := range controller.Array() {
-				for _, namespaceList := range namespaces.Array() {
-					for _, namespace := range namespaceList.Array() {
-						deviceList = append(deviceList, "/dev/"+namespace.String())
-					}
+	devices := gjson.Get(string(nvmeDeviceCmd), "Devices.#.Subsystems.#.Namespaces.#.NameSpace")
+	if len(devices.Array()) > 0 {
+		for _, subsystems := range devices.Array() {
+			for _, namespaces := range subsystems.Array() {
+				for _, namespace := range namespaces.Array() {
+					deviceList = append(deviceList, "/dev/"+namespace.String())
 				}
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -69,7 +69,6 @@ func newNvmeCollector(temperatureScale *string) prometheus.Collector {
 		sensorDescriptions = append(sensorDescriptions, description)
 	}
 
-	fmt.Sprintf("temperature scale: %s", temperatureScale)
 	return &nvmeCollector{
 		temperatureScale: temperatureScale,
 		nvmeCriticalWarning: prometheus.NewDesc(
@@ -282,7 +281,7 @@ func (c *nvmeCollector) makeMetric(description *prometheus.Desc, valType prometh
 	value := gjson.Get(result, substring).Float()
 	if strings.Contains(substring, "temperature") {
 		// Leave it alone, if it's in Kelvin
-		if *c.temperatureScale == "celcius" {
+		if *c.temperatureScale == "celsius" {
 			value = value - 273
 		}
 		if *c.temperatureScale == "fahrenheit" {
@@ -292,73 +291,21 @@ func (c *nvmeCollector) makeMetric(description *prometheus.Desc, valType prometh
 	return prometheus.MustNewConstMetric(description, valType, value, label)
 }
 
-func getDeviceList() []string {
-	/*
-		Modern versions of nvme-cli use 64bit ints for sizes, but have a new JSON format
-		Old version:
-		#  nvme list -o json | jq '.Devices[0]'
-		{
-		  "NameSpace": 1,
-		  "DevicePath": "/dev/nvme0n1",
-		  "Firmware": "XXXXXXXX",
-		  "ModelNumber": "XXXXXXX",
-		  "SerialNumber": "XXXXXXX",
-		  "UsedBytes": -2147483648,
-		  "MaximumLBA": 1875385008,
-		  "PhysicalSize": -2147483648,
-		  "SectorSize": 512
-		}
-		New version:
-		{
-		  "HostNQN": "nqn.2014-08.org.nvmexpress:uuid:XXXXXXX",
-		  "HostID": "XXXXXXX",
-		  "Subsystems": [
-		    {
-		      "Subsystem": "nvme-subsys0",
-		      "SubsystemNQN": "nqn.2016-08.com.micron:nvme:nvm-subsystem-sn-XXXXX",
-		      "Controllers": [
-		        {
-		          "Controller": "nvme0",
-		          "Cntlid": "0",
-		          "SerialNumber": "XXXXXX",
-		          "ModelNumber": "XXXXX",
-		          "Firmware": "XXXXX",
-		          "Transport": "pcie",
-		          "Address": "0000:02:00.0",
-		          "Slot": "9",
-		          "Namespaces": [
-		            {
-		              "NameSpace": "nvme0n1",
-		              "Generic": "ng0n1",
-		              "NSID": 1,
-		              "UsedBytes": 2097152,
-		              "MaximumLBA": 25004872368,
-		              "PhysicalSize": 12802494652416,
-		              "SectorSize": 512
-		            }
-		          ],
-		          "Paths": []
-		        }
-		      ],
-		      "Namespaces": []
-		    },...
-	*/
-	nvmeDeviceCmd, err := exec.Command("nvme", "list", "-o", "json").Output()
-	if err != nil {
-		log.Fatalf("Error running nvme command: %s\n", err)
-	}
-	if !gjson.Valid(string(nvmeDeviceCmd)) {
-		log.Fatal("nvmeDeviceCmd json is not valid")
+func getDeviceList(nvmeListOutput string) []string {
+	// There are three possible formats for
+	if !gjson.Valid(string(nvmeListOutput)) {
+		log.Fatalf("nvmeListOutput json is not valid\n%s", nvmeListOutput)
 	}
 	var deviceList []string
-	nvmeJsonDeviceList := gjson.Get(string(nvmeDeviceCmd), "Devices.#.DevicePath").Array()
+	nvmeJsonDeviceList := gjson.Get(string(nvmeListOutput), "Devices.#.DevicePath").Array()
 	if len(nvmeJsonDeviceList) > 0 {
+		log.Printf("with devicepath Devices: %v\n", nvmeJsonDeviceList)
 		for _, devicePath := range nvmeJsonDeviceList {
 			deviceList = append(deviceList, devicePath.String())
 		}
 		return deviceList
 	}
-	devices := gjson.Get(string(nvmeDeviceCmd), "Devices.#.Subsystems.#.Namespaces.#.NameSpace")
+	devices := gjson.Get(string(nvmeListOutput), "Devices.#.Subsystems.#.Namespaces.#.NameSpace")
 	if len(devices.Array()) > 0 {
 		for _, subsystems := range devices.Array() {
 			for _, namespaces := range subsystems.Array() {
@@ -367,6 +314,24 @@ func getDeviceList() []string {
 				}
 			}
 		}
+	}
+	if len(deviceList) > 0 {
+		log.Printf("without controller Devices: %v\n", deviceList)
+		return deviceList
+	}
+	// Some machines have multiple controllers, and 'nvme list -o json' adds them in, changing the output format
+	devices = gjson.Get(string(nvmeListOutput), "Devices.#.Subsystems.#.Controllers.#.Namespaces.#.NameSpace")
+	if len(devices.Array()) > 0 {
+		for _, subsystems := range devices.Array() {
+			for _, controllers := range subsystems.Array() {
+				for _, namespaces := range controllers.Array() {
+					for _, namespace := range namespaces.Array() {
+						deviceList = append(deviceList, "/dev/"+namespace.String())
+					}
+				}
+			}
+		}
+		log.Printf("with controller Devices: %v\n", deviceList)
 		return deviceList
 	} else {
 		log.Fatal("No NVMe Devices found \n")
@@ -445,7 +410,11 @@ func (c *nvmeCollector) Collect(ch chan<- prometheus.Metric) {
 		}
 
 	*/
-	nvmeDeviceList := getDeviceList()
+	nvmeListOutput, err := exec.Command("nvme", "list", "-o", "json").Output()
+	if err != nil {
+		log.Fatalf("Error running nvme command: %s\n", err)
+	}
+	nvmeDeviceList := getDeviceList(string(nvmeListOutput))
 	for _, nvmeDevice := range nvmeDeviceList {
 		nvmeSmartLog, err := exec.Command("nvme", "smart-log", nvmeDevice, "-o", "json").Output()
 		nvmeSmartLogText := string(nvmeSmartLog)
@@ -505,7 +474,8 @@ func (c *nvmeCollector) Collect(ch chan<- prometheus.Metric) {
 
 func main() {
 	port := flag.String("port", "9998", "port to listen on")
-	temperatureScale := flag.String("temperature_scale", "fahrenheit", "One of : [celcius | fahrenheit | kelvin]. NVMe standard recommens Kelvin.")
+	temperatureScale := flag.String("temperature_scale", "celsius", "One of : [celsius | fahrenheit | kelvin]. NVMe standard recommens Kelvin.")
+	log.Printf("Starting..")
 	flag.Parse()
 	// check user
 	currentUser, err := user.Current()

--- a/main.go
+++ b/main.go
@@ -280,7 +280,7 @@ func (c *nvmeCollector) Describe(ch chan<- *prometheus.Desc) {
 func (c *nvmeCollector) makeMetric(description *prometheus.Desc, valType prometheus.ValueType, result string, substring string, label string) prometheus.Metric {
 	value := gjson.Get(result, substring).Float()
 	if strings.Contains(substring, "temperature") {
-		// Leave it alone, if it's in Kelvin
+		// Leave it alone, if it's in Kelvin, change if it's celsius or fahrenheit
 		if *c.temperatureScale == "celsius" {
 			value = value - 273
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"reflect"
+	"testing"
+)
+
+func TestNewNvmeCollector(t *testing.T) {
+	temperatureScale := "celsius"
+	collector := newNvmeCollector(&temperatureScale)
+
+	if collector == nil {
+		t.Fatalf("Expected newNvmeCollector to return a non-nil value")
+	}
+}
+
+func TestNvmeCollector_Describe(t *testing.T) {
+	temperatureScale := "celsius"
+	collector := newNvmeCollector(&temperatureScale).(*nvmeCollector)
+
+	ch := make(chan *prometheus.Desc)
+	go func() {
+		collector.Describe(ch)
+		close(ch)
+	}()
+
+	for desc := range ch {
+		if desc == nil {
+			t.Errorf("Expected non-nil description")
+		}
+	}
+}
+
+/* TODO: work out how to test metrics, given the internals are hidden
+func TestMakeMetric(t *testing.T) {
+	temperatureScale := "celsius"
+	collector := newNvmeCollector(&temperatureScale).(*nvmeCollector)
+	desc := collector.nvmeTemperature
+	metric := collector.makeMetric(desc, prometheus.GaugeValue, "250", "temperature", "/dev/nvme4n1")
+	if metric == nil {
+		t.Errorf("Expected non-nil metric")
+	}
+	if metric.val!= 250-273 {
+		t.Errorf("Expected %dC, got %d", 250-273, metric)
+	}
+}
+*/
+
+func TestGetDeviceListV1(t *testing.T) {
+	/*
+		Modern versions of nvme-cli use 64bit ints for sizes, but have a new JSON format
+	*/
+	expectedOldDevices := []string{"/dev/nvme0n1"}
+	oldDevicesJson := `{
+      "Devices":[
+			{
+		  "NameSpace": 1,
+		  "DevicePath": "/dev/nvme0n1",
+		  "Firmware": "XXXXXXXX",
+		  "ModelNumber": "XXXXXXX",
+		  "SerialNumber": "XXXXXXX",
+		  "UsedBytes": -2147483648,
+		  "MaximumLBA": 1875385008,
+		  "PhysicalSize": -2147483648,
+		  "SectorSize": 512
+		}
+      ]
+	}`
+	if oldDevices := getDeviceList(oldDevicesJson); !reflect.DeepEqual(oldDevices, expectedOldDevices) {
+		t.Errorf("Expected old format %s, got %s", expectedOldDevices, oldDevices)
+	}
+}
+func TestGetDeviceListV2(t *testing.T) {
+	expectedNewDevices := []string{"/dev/nvme2n1"}
+	newDevicesJson := `{
+      "Devices":[
+		{
+		  "HostNQN": "nqn.2014-08.org.nvmexpress:uuid:XXXXXXX",
+		  "HostID": "XXXXXXX",
+		  "Subsystems": [
+		    {
+		      "Subsystem": "nvme-subsys0",
+		      "SubsystemNQN": "nqn.2016-08.com.micron:nvme:nvm-subsystem-sn-XXXXX",
+		      "Controllers": [
+		        {
+		          "Controller": "nvme2",
+		          "Cntlid": "0",
+		          "SerialNumber": "XXXXXX",
+		          "ModelNumber": "XXXXX",
+		          "Firmware": "XXXXX",
+		          "Transport": "pcie",
+		          "Address": "0000:02:00.0",
+		          "Slot": "9",
+		          "Namespaces": [
+		            {
+		              "NameSpace": "nvme2n1",
+		              "Generic": "ng2n1",
+		              "NSID": 1,
+		              "UsedBytes": 2097152,
+		              "MaximumLBA": 25004872368,
+		              "PhysicalSize": 12802494652416,
+		              "SectorSize": 512
+		            }
+		          ],
+		          "Paths": []
+		        }
+		      ],
+		      "Namespaces": []
+		    }
+		  ]
+		}
+	  ]
+	}`
+	if newDevices := getDeviceList(newDevicesJson); !reflect.DeepEqual(newDevices, expectedNewDevices) {
+		t.Errorf("Expected new format %s, got %s", expectedNewDevices, newDevices)
+	}
+}
+func TestGetDeviceListV3(t *testing.T) {
+	expectedDevices := []string{"/dev/nvme4n1"}
+	devicesJson := `{
+      "Devices":[
+		{
+		  "HostNQN": "nqn.2014-08.org.nvmexpress:uuid:XXXXXXX",
+		  "HostID": "XXXXXXX",
+		  "Subsystems": [
+		    {
+		      "Subsystem": "nvme-subsys0",
+		      "SubsystemNQN": "nqn.2016-08.com.micron:nvme:nvm-subsystem-sn-XXXXX",
+		      "Namespaces": [
+		        {
+		          "NameSpace": "nvme4n1",
+		          "Generic": "ng4n1",
+		          "NSID": 1,
+		          "UsedBytes": 2097152,
+		          "MaximumLBA": 25004872368,
+		          "PhysicalSize": 12802494652416,
+		          "SectorSize": 512
+		        }
+		      ]
+		    }
+		  ]
+		}
+	  ]
+	}`
+	if devices := getDeviceList(devicesJson); !reflect.DeepEqual(devices, expectedDevices) {
+		t.Errorf("Expected new format %s, got %s", expectedDevices, devices)
+	}
+}


### PR DESCRIPTION
Newer versions of nvme-cli use a different JSON format. This change allows nvme_exporter to output all available data, on either version.

Shortcomings:

There are inefficiencies in reprocessing the json output, looking for individual keywords
I've made the temperature scale configurable (default to Fahrenheit, for backward compatibility). It works out if it should mutate a value by checking if it's got 'temperature' in it. People might add values later that are not temperatures, and strange things will happen. But ... if someone adds a temperature, and these reprocessed fields are hard-coded, having some in fahrenheit, some in Kelvin will be confusing too.
nvme-cli 2.0 (RHEL 9):
```
		#  nvme list -o json | jq '.Devices[0]'
		{
		  "NameSpace": 1,
		  "DevicePath": "/dev/nvme0n1",
		  "Firmware": "XXXXXXXX",
		  "ModelNumber": "XXXXXXX",
		  "SerialNumber": "XXXXXXX",
		  "UsedBytes": -2147483648,
		  "MaximumLBA": 1875385008,
		  "PhysicalSize": -2147483648,
		  "SectorSize": 512
		}
```
nvme-cli 2.11 (HEAD as of November 2024):
```
	{
		  "HostNQN": "nqn.2014-08.org.nvmexpress:uuid:XXXXXXX",
		  "HostID": "XXXXXXX",
		  "Subsystems": [
		    {
		      "Subsystem": "nvme-subsys0",
		      "SubsystemNQN": "nqn.2016-08.com.micron:nvme:nvm-subsystem-sn-XXXXX",
		      "Controllers": [
		        {
		          "Controller": "nvme0",
		          "Cntlid": "0",
		          "SerialNumber": "XXXXXX",
		          "ModelNumber": "XXXXX",
		          "Firmware": "XXXXX",
		          "Transport": "pcie",
		          "Address": "0000:02:00.0",
		          "Slot": "9",
		          "Namespaces": [
		            {
		              "NameSpace": "nvme0n1",
		              "Generic": "ng0n1",
		              "NSID": 1,
		              "UsedBytes": 2097152,
		              "MaximumLBA": 25004872368,
		              "PhysicalSize": 12802494652416,
		              "SectorSize": 512
		            }
		          ],
		          "Paths": []
		        }
		      ],
		      "Namespaces": []
		    },...
```
The output of this version of nvme_exporter on the old version of the CLI:

```
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 0
go_gc_duration_seconds{quantile="0.25"} 0
go_gc_duration_seconds{quantile="0.5"} 0
go_gc_duration_seconds{quantile="0.75"} 0
go_gc_duration_seconds{quantile="1"} 0
go_gc_duration_seconds_sum 0
go_gc_duration_seconds_count 0
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 7
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.22.7"} 1
# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 1.345896e+06
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
# TYPE go_memstats_alloc_bytes_total counter
go_memstats_alloc_bytes_total 1.345896e+06
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
# TYPE go_memstats_buck_hash_sys_bytes gauge
go_memstats_buck_hash_sys_bytes 7661
# HELP go_memstats_frees_total Total number of frees.
# TYPE go_memstats_frees_total counter
go_memstats_frees_total 698
# HELP go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
# TYPE go_memstats_gc_cpu_fraction gauge
go_memstats_gc_cpu_fraction 0
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
# TYPE go_memstats_gc_sys_bytes gauge
go_memstats_gc_sys_bytes 1.98628e+06
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
# TYPE go_memstats_heap_alloc_bytes gauge
go_memstats_heap_alloc_bytes 1.345896e+06
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
# TYPE go_memstats_heap_idle_bytes gauge
go_memstats_heap_idle_bytes 5.234688e+06
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
# TYPE go_memstats_heap_inuse_bytes gauge
go_memstats_heap_inuse_bytes 2.6624e+06
# HELP go_memstats_heap_objects Number of allocated objects.
# TYPE go_memstats_heap_objects gauge
go_memstats_heap_objects 4483
# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
# TYPE go_memstats_heap_released_bytes gauge
go_memstats_heap_released_bytes 5.169152e+06
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
# TYPE go_memstats_heap_sys_bytes gauge
go_memstats_heap_sys_bytes 7.897088e+06
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
go_memstats_last_gc_time_seconds 0
# HELP go_memstats_lookups_total Total number of pointer lookups.
# TYPE go_memstats_lookups_total counter
go_memstats_lookups_total 0
# HELP go_memstats_mallocs_total Total number of mallocs.
# TYPE go_memstats_mallocs_total counter
go_memstats_mallocs_total 5181
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
# TYPE go_memstats_mcache_inuse_bytes gauge
go_memstats_mcache_inuse_bytes 19200
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
# TYPE go_memstats_mcache_sys_bytes gauge
go_memstats_mcache_sys_bytes 31200
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
# TYPE go_memstats_mspan_inuse_bytes gauge
go_memstats_mspan_inuse_bytes 75520
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
# TYPE go_memstats_mspan_sys_bytes gauge
go_memstats_mspan_sys_bytes 81600
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
# TYPE go_memstats_next_gc_bytes gauge
go_memstats_next_gc_bytes 4.194304e+06
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
# TYPE go_memstats_other_sys_bytes gauge
go_memstats_other_sys_bytes 1.390235e+06
# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
# TYPE go_memstats_stack_inuse_bytes gauge
go_memstats_stack_inuse_bytes 491520
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
# TYPE go_memstats_stack_sys_bytes gauge
go_memstats_stack_sys_bytes 491520
# HELP go_memstats_sys_bytes Number of bytes obtained from system.
# TYPE go_memstats_sys_bytes gauge
go_memstats_sys_bytes 1.1885584e+07
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
go_threads 7
# HELP nvme_avail_spare Normalized percentage of remaining spare capacity available
# TYPE nvme_avail_spare gauge
nvme_avail_spare{device="/dev/nvme0n1"} 100
# HELP nvme_controller_busy_time Amount of time in minutes controller busy with IO commands
# TYPE nvme_controller_busy_time counter
nvme_controller_busy_time{device="/dev/nvme0n1"} 63
# HELP nvme_critical_comp_time Amount of time in minutes temperature > critical threshold
# TYPE nvme_critical_comp_time counter
nvme_critical_comp_time{device="/dev/nvme0n1"} 0
# HELP nvme_critical_warning Critical warnings for the state of the controller
# TYPE nvme_critical_warning gauge
nvme_critical_warning{device="/dev/nvme0n1"} 0
# HELP nvme_data_units_read Number of 512 byte data units host has read
# TYPE nvme_data_units_read counter
nvme_data_units_read{device="/dev/nvme0n1"} 1.765658e+06
# HELP nvme_data_units_written Number of 512 byte data units the host has written
# TYPE nvme_data_units_written counter
nvme_data_units_written{device="/dev/nvme0n1"} 4.450274e+06
# HELP nvme_endurance_grp_critical_warning_summary Critical warnings for the state of endurance groups
# TYPE nvme_endurance_grp_critical_warning_summary gauge
nvme_endurance_grp_critical_warning_summary{device="/dev/nvme0n1"} 0
# HELP nvme_host_read_commands Number of read commands completed
# TYPE nvme_host_read_commands counter
nvme_host_read_commands{device="/dev/nvme0n1"} 1.95912406e+08
# HELP nvme_host_write_commands Number of write commands completed
# TYPE nvme_host_write_commands counter
nvme_host_write_commands{device="/dev/nvme0n1"} 4.33362594e+08
# HELP nvme_media_errors Number of unrecovered data integrity errors
# TYPE nvme_media_errors counter
nvme_media_errors{device="/dev/nvme0n1"} 0
# HELP nvme_num_err_log_entries Lifetime number of error log entries
# TYPE nvme_num_err_log_entries counter
nvme_num_err_log_entries{device="/dev/nvme0n1"} 0
# HELP nvme_percent_used Vendor specific estimate of the percentage of life used
# TYPE nvme_percent_used gauge
nvme_percent_used{device="/dev/nvme0n1"} 0
# HELP nvme_power_cycles Number of power cycles
# TYPE nvme_power_cycles counter
nvme_power_cycles{device="/dev/nvme0n1"} 27
# HELP nvme_power_on_hours Number of power on hours
# TYPE nvme_power_on_hours counter
nvme_power_on_hours{device="/dev/nvme0n1"} 6288
# HELP nvme_spare_thresh Async event completion may occur when avail spare < threshold
# TYPE nvme_spare_thresh gauge
nvme_spare_thresh{device="/dev/nvme0n1"} 10
# HELP nvme_temperature Temperature in degrees fahrenheit
# TYPE nvme_temperature gauge
nvme_temperature{device="/dev/nvme0n1"} 98.33000000000004
# HELP nvme_thm_temp1_trans_count Number of times controller transitioned to lower power
# TYPE nvme_thm_temp1_trans_count counter
nvme_thm_temp1_trans_count{device="/dev/nvme0n1"} 0
# HELP nvme_thm_temp1_trans_time Total number of seconds controller transitioned to lower power
# TYPE nvme_thm_temp1_trans_time counter
nvme_thm_temp1_trans_time{device="/dev/nvme0n1"} 0
# HELP nvme_thm_temp2_trans_count Number of times controller transitioned to lower power
# TYPE nvme_thm_temp2_trans_count counter
nvme_thm_temp2_trans_count{device="/dev/nvme0n1"} 0
# HELP nvme_thm_temp2_trans_time Total number of seconds controller transitioned to lower power
# TYPE nvme_thm_temp2_trans_time counter
nvme_thm_temp2_trans_time{device="/dev/nvme0n1"} 0
# HELP nvme_unsafe_shutdowns Number of unsafe shutdowns
# TYPE nvme_unsafe_shutdowns counter
nvme_unsafe_shutdowns{device="/dev/nvme0n1"} 21
# HELP nvme_warning_temp_time Amount of time in minutes temperature > warning threshold
# TYPE nvme_warning_temp_time counter
nvme_warning_temp_time{device="/dev/nvme0n1"} 0
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 0
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 524288
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 11
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 1.212416e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.73109726465e+09
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 1.26386176e+09
# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE process_virtual_memory_max_bytes gauge
process_virtual_memory_max_bytes 1.8446744073709552e+19
# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
# TYPE promhttp_metric_handler_requests_in_flight gauge
promhttp_metric_handler_requests_in_flight 1
# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
# TYPE promhttp_metric_handler_requests_total counter
promhttp_metric_handler_requests_total{code="200"} 1
promhttp_metric_handler_requests_total{code="500"} 0
promhttp_metric_handler_requests_total{code="503"} 0
```

The output of this version of nvme_exporter on nvme-cli 2.11:

```
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 0
go_gc_duration_seconds{quantile="0.25"} 0
go_gc_duration_seconds{quantile="0.5"} 0
go_gc_duration_seconds{quantile="0.75"} 0
go_gc_duration_seconds{quantile="1"} 0
go_gc_duration_seconds_sum 0
go_gc_duration_seconds_count 0
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 7
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.22.7"} 1
# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 900416
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
# TYPE go_memstats_alloc_bytes_total counter
go_memstats_alloc_bytes_total 900416
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
# TYPE go_memstats_buck_hash_sys_bytes gauge
go_memstats_buck_hash_sys_bytes 7661
# HELP go_memstats_frees_total Total number of frees.
# TYPE go_memstats_frees_total counter
go_memstats_frees_total 146
# HELP go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
# TYPE go_memstats_gc_cpu_fraction gauge
go_memstats_gc_cpu_fraction 0
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
# TYPE go_memstats_gc_sys_bytes gauge
go_memstats_gc_sys_bytes 1.86292e+06
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
# TYPE go_memstats_heap_alloc_bytes gauge
go_memstats_heap_alloc_bytes 900416
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
# TYPE go_memstats_heap_idle_bytes gauge
go_memstats_heap_idle_bytes 1.646592e+06
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
# TYPE go_memstats_heap_inuse_bytes gauge
go_memstats_heap_inuse_bytes 2.023424e+06
# HELP go_memstats_heap_objects Number of allocated objects.
# TYPE go_memstats_heap_objects gauge
go_memstats_heap_objects 2424
# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
# TYPE go_memstats_heap_released_bytes gauge
go_memstats_heap_released_bytes 1.646592e+06
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
# TYPE go_memstats_heap_sys_bytes gauge
go_memstats_heap_sys_bytes 3.670016e+06
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
go_memstats_last_gc_time_seconds 0
# HELP go_memstats_lookups_total Total number of pointer lookups.
# TYPE go_memstats_lookups_total counter
go_memstats_lookups_total 0
# HELP go_memstats_mallocs_total Total number of mallocs.
# TYPE go_memstats_mallocs_total counter
go_memstats_mallocs_total 2570
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
# TYPE go_memstats_mcache_inuse_bytes gauge
go_memstats_mcache_inuse_bytes 38400
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
# TYPE go_memstats_mcache_sys_bytes gauge
go_memstats_mcache_sys_bytes 46800
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
# TYPE go_memstats_mspan_inuse_bytes gauge
go_memstats_mspan_inuse_bytes 65280
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
# TYPE go_memstats_mspan_sys_bytes gauge
go_memstats_mspan_sys_bytes 65280
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
# TYPE go_memstats_next_gc_bytes gauge
go_memstats_next_gc_bytes 4.194304e+06
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
# TYPE go_memstats_other_sys_bytes gauge
go_memstats_other_sys_bytes 990027
# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
# TYPE go_memstats_stack_inuse_bytes gauge
go_memstats_stack_inuse_bytes 524288
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
# TYPE go_memstats_stack_sys_bytes gauge
go_memstats_stack_sys_bytes 524288
# HELP go_memstats_sys_bytes Number of bytes obtained from system.
# TYPE go_memstats_sys_bytes gauge
go_memstats_sys_bytes 7.166992e+06
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
go_threads 6
# HELP nvme_avail_spare Normalized percentage of remaining spare capacity available
# TYPE nvme_avail_spare gauge
nvme_avail_spare{device="/dev/nvme0n1"} 100
nvme_avail_spare{device="/dev/nvme1n1"} 100
nvme_avail_spare{device="/dev/nvme2n1"} 100
nvme_avail_spare{device="/dev/nvme3n1"} 100
nvme_avail_spare{device="/dev/nvme4n1"} 100
nvme_avail_spare{device="/dev/nvme5n1"} 100
nvme_avail_spare{device="/dev/nvme6n1"} 100
nvme_avail_spare{device="/dev/nvme7n1"} 100
# HELP nvme_available_spare_critical Has the 'available_spare' value dropped below 'spare_thresh'
# TYPE nvme_available_spare_critical gauge
nvme_available_spare_critical{device="/dev/nvme0n1"} 0
nvme_available_spare_critical{device="/dev/nvme1n1"} 0
nvme_available_spare_critical{device="/dev/nvme2n1"} 0
nvme_available_spare_critical{device="/dev/nvme3n1"} 0
nvme_available_spare_critical{device="/dev/nvme4n1"} 0
nvme_available_spare_critical{device="/dev/nvme5n1"} 0
nvme_available_spare_critical{device="/dev/nvme6n1"} 0
nvme_available_spare_critical{device="/dev/nvme7n1"} 0
# HELP nvme_controller_busy_time Amount of time in minutes controller busy with IO commands
# TYPE nvme_controller_busy_time counter
nvme_controller_busy_time{device="/dev/nvme0n1"} 1
nvme_controller_busy_time{device="/dev/nvme1n1"} 0
nvme_controller_busy_time{device="/dev/nvme2n1"} 4
nvme_controller_busy_time{device="/dev/nvme3n1"} 6
nvme_controller_busy_time{device="/dev/nvme4n1"} 2
nvme_controller_busy_time{device="/dev/nvme5n1"} 0
nvme_controller_busy_time{device="/dev/nvme6n1"} 0
nvme_controller_busy_time{device="/dev/nvme7n1"} 0
# HELP nvme_critical_comp_time Amount of time in minutes temperature > critical threshold
# TYPE nvme_critical_comp_time counter
nvme_critical_comp_time{device="/dev/nvme0n1"} 0
nvme_critical_comp_time{device="/dev/nvme1n1"} 0
nvme_critical_comp_time{device="/dev/nvme2n1"} 0
nvme_critical_comp_time{device="/dev/nvme3n1"} 0
nvme_critical_comp_time{device="/dev/nvme4n1"} 0
nvme_critical_comp_time{device="/dev/nvme5n1"} 0
nvme_critical_comp_time{device="/dev/nvme6n1"} 0
nvme_critical_comp_time{device="/dev/nvme7n1"} 0
# HELP nvme_critical_warning Critical warnings for the state of the controller
# TYPE nvme_critical_warning gauge
nvme_critical_warning{device="/dev/nvme0n1"} 0
nvme_critical_warning{device="/dev/nvme1n1"} 0
nvme_critical_warning{device="/dev/nvme2n1"} 0
nvme_critical_warning{device="/dev/nvme3n1"} 0
nvme_critical_warning{device="/dev/nvme4n1"} 0
nvme_critical_warning{device="/dev/nvme5n1"} 0
nvme_critical_warning{device="/dev/nvme6n1"} 0
nvme_critical_warning{device="/dev/nvme7n1"} 0
# HELP nvme_data_units_read Number of 512 byte data units host has read
# TYPE nvme_data_units_read counter
nvme_data_units_read{device="/dev/nvme0n1"} 4541
nvme_data_units_read{device="/dev/nvme1n1"} 1078
nvme_data_units_read{device="/dev/nvme2n1"} 795896
nvme_data_units_read{device="/dev/nvme3n1"} 799545
nvme_data_units_read{device="/dev/nvme4n1"} 19981
nvme_data_units_read{device="/dev/nvme5n1"} 3287
nvme_data_units_read{device="/dev/nvme6n1"} 968
nvme_data_units_read{device="/dev/nvme7n1"} 1176
# HELP nvme_data_units_written Number of 512 byte data units the host has written
# TYPE nvme_data_units_written counter
nvme_data_units_written{device="/dev/nvme0n1"} 16778
nvme_data_units_written{device="/dev/nvme1n1"} 99
nvme_data_units_written{device="/dev/nvme2n1"} 1.005368e+06
nvme_data_units_written{device="/dev/nvme3n1"} 2.58958e+06
nvme_data_units_written{device="/dev/nvme4n1"} 44091
nvme_data_units_written{device="/dev/nvme5n1"} 19203
nvme_data_units_written{device="/dev/nvme6n1"} 99
nvme_data_units_written{device="/dev/nvme7n1"} 107
# HELP nvme_endurance_grp_critical_warning_summary Critical warnings for the state of endurance groups
# TYPE nvme_endurance_grp_critical_warning_summary gauge
nvme_endurance_grp_critical_warning_summary{device="/dev/nvme0n1"} 0
nvme_endurance_grp_critical_warning_summary{device="/dev/nvme1n1"} 0
nvme_endurance_grp_critical_warning_summary{device="/dev/nvme2n1"} 0
nvme_endurance_grp_critical_warning_summary{device="/dev/nvme3n1"} 0
nvme_endurance_grp_critical_warning_summary{device="/dev/nvme4n1"} 0
nvme_endurance_grp_critical_warning_summary{device="/dev/nvme5n1"} 0
nvme_endurance_grp_critical_warning_summary{device="/dev/nvme6n1"} 0
nvme_endurance_grp_critical_warning_summary{device="/dev/nvme7n1"} 0
# HELP nvme_host_read_commands Number of read commands completed
# TYPE nvme_host_read_commands counter
nvme_host_read_commands{device="/dev/nvme0n1"} 151177
nvme_host_read_commands{device="/dev/nvme1n1"} 19585
nvme_host_read_commands{device="/dev/nvme2n1"} 3.874525e+06
nvme_host_read_commands{device="/dev/nvme3n1"} 3.905098e+06
nvme_host_read_commands{device="/dev/nvme4n1"} 443973
nvme_host_read_commands{device="/dev/nvme5n1"} 96062
nvme_host_read_commands{device="/dev/nvme6n1"} 18448
nvme_host_read_commands{device="/dev/nvme7n1"} 21268
# HELP nvme_host_write_commands Number of write commands completed
# TYPE nvme_host_write_commands counter
nvme_host_write_commands{device="/dev/nvme0n1"} 99578
nvme_host_write_commands{device="/dev/nvme1n1"} 384
nvme_host_write_commands{device="/dev/nvme2n1"} 8.492726e+06
nvme_host_write_commands{device="/dev/nvme3n1"} 1.4822808e+07
nvme_host_write_commands{device="/dev/nvme4n1"} 497896
nvme_host_write_commands{device="/dev/nvme5n1"} 179405
nvme_host_write_commands{device="/dev/nvme6n1"} 384
nvme_host_write_commands{device="/dev/nvme7n1"} 6816
# HELP nvme_media_errors Number of unrecovered data integrity errors
# TYPE nvme_media_errors counter
nvme_media_errors{device="/dev/nvme0n1"} 0
nvme_media_errors{device="/dev/nvme1n1"} 0
nvme_media_errors{device="/dev/nvme2n1"} 0
nvme_media_errors{device="/dev/nvme3n1"} 0
nvme_media_errors{device="/dev/nvme4n1"} 0
nvme_media_errors{device="/dev/nvme5n1"} 0
nvme_media_errors{device="/dev/nvme6n1"} 0
nvme_media_errors{device="/dev/nvme7n1"} 0
# HELP nvme_num_err_log_entries Lifetime number of error log entries
# TYPE nvme_num_err_log_entries counter
nvme_num_err_log_entries{device="/dev/nvme0n1"} 0
nvme_num_err_log_entries{device="/dev/nvme1n1"} 0
nvme_num_err_log_entries{device="/dev/nvme2n1"} 0
nvme_num_err_log_entries{device="/dev/nvme3n1"} 1
nvme_num_err_log_entries{device="/dev/nvme4n1"} 0
nvme_num_err_log_entries{device="/dev/nvme5n1"} 0
nvme_num_err_log_entries{device="/dev/nvme6n1"} 0
nvme_num_err_log_entries{device="/dev/nvme7n1"} 0
# HELP nvme_percent_used Vendor specific estimate of the percentage of life used
# TYPE nvme_percent_used gauge
nvme_percent_used{device="/dev/nvme0n1"} 0
nvme_percent_used{device="/dev/nvme1n1"} 0
nvme_percent_used{device="/dev/nvme2n1"} 0
nvme_percent_used{device="/dev/nvme3n1"} 0
nvme_percent_used{device="/dev/nvme4n1"} 0
nvme_percent_used{device="/dev/nvme5n1"} 0
nvme_percent_used{device="/dev/nvme6n1"} 0
nvme_percent_used{device="/dev/nvme7n1"} 0
# HELP nvme_pmr_ro The Persistent Memory Region is currently read-only
# TYPE nvme_pmr_ro gauge
nvme_pmr_ro{device="/dev/nvme0n1"} 0
nvme_pmr_ro{device="/dev/nvme1n1"} 0
nvme_pmr_ro{device="/dev/nvme2n1"} 0
nvme_pmr_ro{device="/dev/nvme3n1"} 0
nvme_pmr_ro{device="/dev/nvme4n1"} 0
nvme_pmr_ro{device="/dev/nvme5n1"} 0
nvme_pmr_ro{device="/dev/nvme6n1"} 0
nvme_pmr_ro{device="/dev/nvme7n1"} 0
# HELP nvme_power_cycles Number of power cycles
# TYPE nvme_power_cycles counter
nvme_power_cycles{device="/dev/nvme0n1"} 31
nvme_power_cycles{device="/dev/nvme1n1"} 32
nvme_power_cycles{device="/dev/nvme2n1"} 31
nvme_power_cycles{device="/dev/nvme3n1"} 31
nvme_power_cycles{device="/dev/nvme4n1"} 31
nvme_power_cycles{device="/dev/nvme5n1"} 31
nvme_power_cycles{device="/dev/nvme6n1"} 31
nvme_power_cycles{device="/dev/nvme7n1"} 31
# HELP nvme_power_on_hours Number of power on hours
# TYPE nvme_power_on_hours counter
nvme_power_on_hours{device="/dev/nvme0n1"} 912
nvme_power_on_hours{device="/dev/nvme1n1"} 912
nvme_power_on_hours{device="/dev/nvme2n1"} 912
nvme_power_on_hours{device="/dev/nvme3n1"} 912
nvme_power_on_hours{device="/dev/nvme4n1"} 912
nvme_power_on_hours{device="/dev/nvme5n1"} 912
nvme_power_on_hours{device="/dev/nvme6n1"} 912
nvme_power_on_hours{device="/dev/nvme7n1"} 912
# HELP nvme_readonly NVMe device is currently read-only
# TYPE nvme_readonly gauge
nvme_readonly{device="/dev/nvme0n1"} 0
nvme_readonly{device="/dev/nvme1n1"} 0
nvme_readonly{device="/dev/nvme2n1"} 0
nvme_readonly{device="/dev/nvme3n1"} 0
nvme_readonly{device="/dev/nvme4n1"} 0
nvme_readonly{device="/dev/nvme5n1"} 0
nvme_readonly{device="/dev/nvme6n1"} 0
nvme_readonly{device="/dev/nvme7n1"} 0
# HELP nvme_reliability_degraded Device has degraded reliability due to excessive media/internal errors
# TYPE nvme_reliability_degraded gauge
nvme_reliability_degraded{device="/dev/nvme0n1"} 0
nvme_reliability_degraded{device="/dev/nvme1n1"} 0
nvme_reliability_degraded{device="/dev/nvme2n1"} 0
nvme_reliability_degraded{device="/dev/nvme3n1"} 0
nvme_reliability_degraded{device="/dev/nvme4n1"} 0
nvme_reliability_degraded{device="/dev/nvme5n1"} 0
nvme_reliability_degraded{device="/dev/nvme6n1"} 0
nvme_reliability_degraded{device="/dev/nvme7n1"} 0
# HELP nvme_spare_thresh Async event completion may occur when avail spare < threshold
# TYPE nvme_spare_thresh gauge
nvme_spare_thresh{device="/dev/nvme0n1"} 10
nvme_spare_thresh{device="/dev/nvme1n1"} 10
nvme_spare_thresh{device="/dev/nvme2n1"} 10
nvme_spare_thresh{device="/dev/nvme3n1"} 10
nvme_spare_thresh{device="/dev/nvme4n1"} 10
nvme_spare_thresh{device="/dev/nvme5n1"} 10
nvme_spare_thresh{device="/dev/nvme6n1"} 10
nvme_spare_thresh{device="/dev/nvme7n1"} 10
# HELP nvme_temp_threshold_exceeded Temperature has exceeded the safe threshold
# TYPE nvme_temp_threshold_exceeded gauge
nvme_temp_threshold_exceeded{device="/dev/nvme0n1"} 0
nvme_temp_threshold_exceeded{device="/dev/nvme1n1"} 0
nvme_temp_threshold_exceeded{device="/dev/nvme2n1"} 0
nvme_temp_threshold_exceeded{device="/dev/nvme3n1"} 0
nvme_temp_threshold_exceeded{device="/dev/nvme4n1"} 0
nvme_temp_threshold_exceeded{device="/dev/nvme5n1"} 0
nvme_temp_threshold_exceeded{device="/dev/nvme6n1"} 0
nvme_temp_threshold_exceeded{device="/dev/nvme7n1"} 0
# HELP nvme_temperature Temperature in degrees celcius
# TYPE nvme_temperature gauge
nvme_temperature{device="/dev/nvme0n1"} 23
nvme_temperature{device="/dev/nvme1n1"} 24
nvme_temperature{device="/dev/nvme2n1"} 23
nvme_temperature{device="/dev/nvme3n1"} 24
nvme_temperature{device="/dev/nvme4n1"} 23
nvme_temperature{device="/dev/nvme5n1"} 23
nvme_temperature{device="/dev/nvme6n1"} 23
nvme_temperature{device="/dev/nvme7n1"} 23
# HELP nvme_temperature_sensor1 Temperature reported by thermal sensor #1 in degrees celcius
# TYPE nvme_temperature_sensor1 gauge
nvme_temperature_sensor1{device="/dev/nvme0n1"} 29
nvme_temperature_sensor1{device="/dev/nvme1n1"} 29
nvme_temperature_sensor1{device="/dev/nvme2n1"} 29
nvme_temperature_sensor1{device="/dev/nvme3n1"} 29
nvme_temperature_sensor1{device="/dev/nvme4n1"} 29
nvme_temperature_sensor1{device="/dev/nvme5n1"} 28
nvme_temperature_sensor1{device="/dev/nvme6n1"} 29
nvme_temperature_sensor1{device="/dev/nvme7n1"} 28
# HELP nvme_temperature_sensor2 Temperature reported by thermal sensor #2 in degrees celcius
# TYPE nvme_temperature_sensor2 gauge
nvme_temperature_sensor2{device="/dev/nvme0n1"} 25
nvme_temperature_sensor2{device="/dev/nvme1n1"} 26
nvme_temperature_sensor2{device="/dev/nvme2n1"} 25
nvme_temperature_sensor2{device="/dev/nvme3n1"} 27
nvme_temperature_sensor2{device="/dev/nvme4n1"} 26
nvme_temperature_sensor2{device="/dev/nvme5n1"} 26
nvme_temperature_sensor2{device="/dev/nvme6n1"} 25
nvme_temperature_sensor2{device="/dev/nvme7n1"} 26
# HELP nvme_temperature_sensor3 Temperature reported by thermal sensor #3 in degrees celcius
# TYPE nvme_temperature_sensor3 gauge
nvme_temperature_sensor3{device="/dev/nvme0n1"} 23
nvme_temperature_sensor3{device="/dev/nvme1n1"} 24
nvme_temperature_sensor3{device="/dev/nvme2n1"} 23
nvme_temperature_sensor3{device="/dev/nvme3n1"} 23
nvme_temperature_sensor3{device="/dev/nvme4n1"} 23
nvme_temperature_sensor3{device="/dev/nvme5n1"} 23
nvme_temperature_sensor3{device="/dev/nvme6n1"} 23
nvme_temperature_sensor3{device="/dev/nvme7n1"} 23
# HELP nvme_thm_temp1_trans_count Number of times controller transitioned to lower power
# TYPE nvme_thm_temp1_trans_count counter
nvme_thm_temp1_trans_count{device="/dev/nvme0n1"} 0
nvme_thm_temp1_trans_count{device="/dev/nvme1n1"} 0
nvme_thm_temp1_trans_count{device="/dev/nvme2n1"} 0
nvme_thm_temp1_trans_count{device="/dev/nvme3n1"} 0
nvme_thm_temp1_trans_count{device="/dev/nvme4n1"} 0
nvme_thm_temp1_trans_count{device="/dev/nvme5n1"} 0
nvme_thm_temp1_trans_count{device="/dev/nvme6n1"} 0
nvme_thm_temp1_trans_count{device="/dev/nvme7n1"} 0
# HELP nvme_thm_temp1_trans_time Total number of seconds controller transitioned to lower power
# TYPE nvme_thm_temp1_trans_time counter
nvme_thm_temp1_trans_time{device="/dev/nvme0n1"} 0
nvme_thm_temp1_trans_time{device="/dev/nvme1n1"} 0
nvme_thm_temp1_trans_time{device="/dev/nvme2n1"} 0
nvme_thm_temp1_trans_time{device="/dev/nvme3n1"} 0
nvme_thm_temp1_trans_time{device="/dev/nvme4n1"} 0
nvme_thm_temp1_trans_time{device="/dev/nvme5n1"} 0
nvme_thm_temp1_trans_time{device="/dev/nvme6n1"} 0
nvme_thm_temp1_trans_time{device="/dev/nvme7n1"} 0
# HELP nvme_thm_temp2_trans_count Number of times controller transitioned to lower power
# TYPE nvme_thm_temp2_trans_count counter
nvme_thm_temp2_trans_count{device="/dev/nvme0n1"} 0
nvme_thm_temp2_trans_count{device="/dev/nvme1n1"} 0
nvme_thm_temp2_trans_count{device="/dev/nvme2n1"} 0
nvme_thm_temp2_trans_count{device="/dev/nvme3n1"} 0
nvme_thm_temp2_trans_count{device="/dev/nvme4n1"} 0
nvme_thm_temp2_trans_count{device="/dev/nvme5n1"} 0
nvme_thm_temp2_trans_count{device="/dev/nvme6n1"} 0
nvme_thm_temp2_trans_count{device="/dev/nvme7n1"} 0
# HELP nvme_thm_temp2_trans_time Total number of seconds controller transitioned to lower power
# TYPE nvme_thm_temp2_trans_time counter
nvme_thm_temp2_trans_time{device="/dev/nvme0n1"} 0
nvme_thm_temp2_trans_time{device="/dev/nvme1n1"} 0
nvme_thm_temp2_trans_time{device="/dev/nvme2n1"} 0
nvme_thm_temp2_trans_time{device="/dev/nvme3n1"} 0
nvme_thm_temp2_trans_time{device="/dev/nvme4n1"} 0
nvme_thm_temp2_trans_time{device="/dev/nvme5n1"} 0
nvme_thm_temp2_trans_time{device="/dev/nvme6n1"} 0
nvme_thm_temp2_trans_time{device="/dev/nvme7n1"} 0
# HELP nvme_unsafe_shutdowns Number of unsafe shutdowns
# TYPE nvme_unsafe_shutdowns counter
nvme_unsafe_shutdowns{device="/dev/nvme0n1"} 24
nvme_unsafe_shutdowns{device="/dev/nvme1n1"} 25
nvme_unsafe_shutdowns{device="/dev/nvme2n1"} 24
nvme_unsafe_shutdowns{device="/dev/nvme3n1"} 24
nvme_unsafe_shutdowns{device="/dev/nvme4n1"} 23
nvme_unsafe_shutdowns{device="/dev/nvme5n1"} 22
nvme_unsafe_shutdowns{device="/dev/nvme6n1"} 18
nvme_unsafe_shutdowns{device="/dev/nvme7n1"} 17
# HELP nvme_vmbu_failed The 'Volatile Memory Backup Device' has failed, if present
# TYPE nvme_vmbu_failed gauge
nvme_vmbu_failed{device="/dev/nvme0n1"} 0
nvme_vmbu_failed{device="/dev/nvme1n1"} 0
nvme_vmbu_failed{device="/dev/nvme2n1"} 0
nvme_vmbu_failed{device="/dev/nvme3n1"} 0
nvme_vmbu_failed{device="/dev/nvme4n1"} 0
nvme_vmbu_failed{device="/dev/nvme5n1"} 0
nvme_vmbu_failed{device="/dev/nvme6n1"} 0
nvme_vmbu_failed{device="/dev/nvme7n1"} 0
# HELP nvme_warning_temp_time Amount of time in minutes temperature > warning threshold
# TYPE nvme_warning_temp_time counter
nvme_warning_temp_time{device="/dev/nvme0n1"} 0
nvme_warning_temp_time{device="/dev/nvme1n1"} 0
nvme_warning_temp_time{device="/dev/nvme2n1"} 0
nvme_warning_temp_time{device="/dev/nvme3n1"} 0
nvme_warning_temp_time{device="/dev/nvme4n1"} 0
nvme_warning_temp_time{device="/dev/nvme5n1"} 0
nvme_warning_temp_time{device="/dev/nvme6n1"} 0
nvme_warning_temp_time{device="/dev/nvme7n1"} 0
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 0
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 524288
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 11
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 7.573504e+06
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.73109715861e+09
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 1.26255104e+09
# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE process_virtual_memory_max_bytes gauge
process_virtual_memory_max_bytes 1.8446744073709552e+19
# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
# TYPE promhttp_metric_handler_requests_in_flight gauge
promhttp_metric_handler_requests_in_flight 1
# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
# TYPE promhttp_metric_handler_requests_total counter
promhttp_metric_handler_requests_total{code="200"} 0
promhttp_metric_handler_requests_total{code="500"} 0
promhttp_metric_handler_requests_total{code="503"} 0
```